### PR TITLE
CommunityToolkit.Mvvm support option 1

### DIFF
--- a/src/FreshMvvm.Maui.Observable/FreshBaseObservablePageModel.cs
+++ b/src/FreshMvvm.Maui.Observable/FreshBaseObservablePageModel.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.ObjectModel;
+
+namespace FreshMvvm.Maui.Observable;
+
+public abstract partial class FreshBaseObservablePageModel : ObservableObject, IFreshPageModel
+{
+    NavigationPage _navigationPage;
+
+    /// <summary>
+    /// This event is raise when a page is Popped, this might not be raise everytime a page is Popped. 
+    /// Note* this might be raised multiple times. 
+    /// </summary>
+    public event EventHandler PageWasPopped;
+
+    /// <summary>
+    /// This property is used by the FreshBaseContentPage and allows you to set the toolbar items on the page.
+    /// </summary>
+    public ObservableCollection<ToolbarItem> ToolbarItems { get; set; }
+
+    /// <summary>
+    /// The previous page model, that's automatically filled, on push
+    /// </summary>
+    public IFreshPageModel PreviousPageModel { get; set; }
+
+    /// <summary>
+    /// A reference to the current page, that's automatically filled, on push
+    /// </summary>
+    public Page CurrentPage { get; set; }
+
+    public void SetCurrentPage(Page page)
+    {
+        CurrentPage = page;
+        WireEvents(page);
+    }
+
+    /// <summary>
+    /// Core methods are basic built in methods for the App including Pushing, Pop and Alert
+    /// </summary>
+    public IPageModelCoreMethods CoreMethods { get; set; }
+
+    /// <summary>
+    /// This method is called when a page is Pop'd, it also allows for data to be returned.
+    /// </summary>
+    /// <param name="returnedData">This data that's returned from </param>
+    public virtual void ReverseInit(object returnedData)
+    {
+    }
+
+    /// <summary>
+    /// This method is called when the PageModel is loaded, the initData is the data that's sent from pagemodel before
+    /// </summary>
+    /// <param name="initData">Data that's sent to this PageModel from the pusher</param>
+    public virtual void Init(object initData)
+    {
+    }
+
+    internal void WireEvents(Page page)
+    {
+        page.Appearing += new WeakEventHandler<EventArgs>(ViewIsAppearing).Handler;
+        page.Disappearing += new WeakEventHandler<EventArgs>(ViewIsDisappearing).Handler;
+    }
+
+    /// <summary>
+    /// Is true when this model is the first of a new navigation stack
+    /// </summary>
+    public bool IsModalFirstChild { get; set; }
+
+    /// <summary>
+    /// Used when a page is shown modal and wants a new Navigation Stack
+    /// </summary>
+    public IFreshNavigationService PreviousNavigationService { internal set; get; }
+
+    public void SetPreviousNavigationService(IFreshNavigationService freshNavigationService)
+    {
+        PreviousNavigationService = freshNavigationService;
+    }
+
+    /// <summary>
+    /// Used when a page is shown modal and wants a new Navigation Stack
+    /// </summary>
+    public IFreshNavigationService CurrentNavigationService { internal set; get; }
+
+    /// <summary>
+    /// To be used only when creating your own navigation container
+    /// </summary>
+    public void SetCurrentNavigationService(IFreshNavigationService freshNavigationService)
+    {
+        CurrentNavigationService = freshNavigationService;
+    }
+
+    /// <summary>
+    /// This means the current PageModel is shown modally and can be pop'd modally
+    /// </summary>
+    public bool IsModalAndHasPreviousNavigationStack()
+    {
+        return PreviousNavigationService != null;
+    }
+
+    /// <summary>
+    /// This method is called when the view is disappearing. 
+    /// </summary>
+    protected virtual void ViewIsDisappearing (object sender, EventArgs e)
+    {
+
+    }
+
+    /// <summary>
+    /// This methods is called when the View is appearing
+    /// </summary>
+    protected virtual void ViewIsAppearing (object sender, EventArgs e)
+    {
+        if (!_alreadyAttached)
+            AttachPageWasPoppedEvent();
+    }
+
+    bool _alreadyAttached = false;
+    /// <summary>
+    /// This is used to attach the page was popped method to a NavigationPage if available
+    /// </summary>
+    void AttachPageWasPoppedEvent()
+    {
+        var navPage = (this.CurrentPage.Parent as NavigationPage);
+        if (navPage != null)
+        {
+            _navigationPage = navPage;
+            _alreadyAttached = true;
+            navPage.Popped += new WeakEventHandler<NavigationEventArgs>(HandleNavPagePopped).Handler;
+        }
+    }
+
+    void HandleNavPagePopped(object sender, NavigationEventArgs e)
+    {
+        if (e.Page == this.CurrentPage)
+        {
+            RaisePageWasPopped();
+        }
+    }
+
+    public void RaisePageWasPopped()
+    {
+        if (PageWasPopped != null)
+            PageWasPopped(this, EventArgs.Empty);
+
+        var navPage = (this.CurrentPage.Parent as NavigationPage);
+        if (navPage != null)
+            navPage.Popped -= HandleNavPagePopped;
+
+        if (_navigationPage != null)
+            _navigationPage.Popped -= HandleNavPagePopped;
+
+        _navigationPage = null;
+
+        CurrentPage.Appearing -= ViewIsAppearing;
+        CurrentPage.Disappearing -= ViewIsDisappearing;
+        CurrentPage.BindingContext = null;
+    }
+}

--- a/src/FreshMvvm.Maui.Observable/FreshMvvm.Maui.Observable.csproj
+++ b/src/FreshMvvm.Maui.Observable/FreshMvvm.Maui.Observable.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0</TargetFrameworks>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<UseMaui>true</UseMaui>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+	  	<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\FreshMvvm.Maui\FreshMvvm.Maui.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/FreshMvvm.Maui/FreshBasePageModel.cs
+++ b/src/FreshMvvm.Maui/FreshBasePageModel.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using System.Runtime.CompilerServices;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 
 namespace FreshMvvm.Maui
 {
-    public abstract class FreshBasePageModel : INotifyPropertyChanged
+    public abstract class FreshBasePageModel : INotifyPropertyChanged, IFreshPageModel
     {
         NavigationPage _navigationPage;
 
@@ -29,12 +26,18 @@ namespace FreshMvvm.Maui
         /// <summary>
         /// The previous page model, that's automatically filled, on push
         /// </summary>
-        public FreshBasePageModel PreviousPageModel { get; set; }
+        public IFreshPageModel PreviousPageModel { get; set; }
 
         /// <summary>
         /// A reference to the current page, that's automatically filled, on push
         /// </summary>
         public Page CurrentPage { get; set; }
+
+        public void SetCurrentPage(Page page)
+        {
+            CurrentPage = page;
+            WireEvents(page);
+        }
 
         /// <summary>
         /// Core methods are basic built in methods for the App including Pushing, Pop and Alert
@@ -74,12 +77,17 @@ namespace FreshMvvm.Maui
         /// <summary>
         /// Is true when this model is the first of a new navigation stack
         /// </summary>
-        public bool IsModalFirstChild;
+        public bool IsModalFirstChild { get; set; }
 
         /// <summary>
         /// Used when a page is shown modal and wants a new Navigation Stack
         /// </summary>
         public IFreshNavigationService PreviousNavigationService { internal set; get; }
+
+        public void SetPreviousNavigationService(IFreshNavigationService freshNavigationService)
+        {
+            PreviousNavigationService = freshNavigationService;
+        }
 
         /// <summary>
         /// Used when a page is shown modal and wants a new Navigation Stack

--- a/src/FreshMvvm.Maui/FreshPageModelResolver.cs
+++ b/src/FreshMvvm.Maui/FreshPageModelResolver.cs
@@ -8,19 +8,19 @@ namespace FreshMvvm.Maui
     {
         public static IFreshPageModelMapper PageModelMapper { get; set; } = new FreshPageModelMapper();
 
-        public static Page ResolvePageModel<T> () where T : FreshBasePageModel
+        public static Page ResolvePageModel<T> () where T : class, IFreshPageModel
         {
             return ResolvePageModel<T> (null);
         }
 
-        public static Page ResolvePageModel<T> (object initData) where T : FreshBasePageModel
+        public static Page ResolvePageModel<T> (object initData) where T : class, IFreshPageModel
         {
             var pageModel = DependancyService.Resolve<T> ();
 
             return ResolvePageModel<T> (initData, pageModel);
         }
 
-        public static Page ResolvePageModel<T> (object data, T pageModel) where T : FreshBasePageModel
+        public static Page ResolvePageModel<T> (object data, T pageModel) where T : class, IFreshPageModel
         {
             var type = pageModel.GetType ();
             return ResolvePageModel (type, data, pageModel);
@@ -28,11 +28,11 @@ namespace FreshMvvm.Maui
 
         public static Page ResolvePageModel (Type type, object data) 
         {
-            var pageModel = DependancyService.Resolve(type) as FreshBasePageModel;
+            var pageModel = DependancyService.Resolve(type) as IFreshPageModel;
             return ResolvePageModel (type, data, pageModel);
         }
 
-        public static Page ResolvePageModel (Type type, object data, FreshBasePageModel pageModel)
+        public static Page ResolvePageModel (Type type, object data, IFreshPageModel pageModel)
         {
             var name = PageModelMapper.GetPageTypeName (type);
             var pageType = Type.GetType (name);
@@ -46,10 +46,11 @@ namespace FreshMvvm.Maui
             return page;
         }
 
-        public static Page BindingPageModel(object data, Page targetPage, FreshBasePageModel pageModel)
+        public static Page BindingPageModel(object data, Page targetPage, IFreshPageModel pageModel)
         {
-            pageModel.WireEvents (targetPage);
-            pageModel.CurrentPage = targetPage;
+            // pageModel.WireEvents (targetPage);
+            // pageModel.CurrentPage = targetPage;
+            pageModel.SetCurrentPage (targetPage);
             pageModel.CoreMethods = new PageModelCoreMethods (targetPage, pageModel);
             pageModel.Init (data);
             targetPage.BindingContext = pageModel;

--- a/src/FreshMvvm.Maui/IFreshNavigationService.cs
+++ b/src/FreshMvvm.Maui/IFreshNavigationService.cs
@@ -8,7 +8,7 @@ namespace FreshMvvm.Maui
     {
         Task PopToRoot(bool animate = true);
 
-		Task PushPage (Page page, FreshBasePageModel model, bool modal = false, bool animate = true);
+		Task PushPage (Page page, IFreshPageModel model, bool modal = false, bool animate = true);
 
         Task PopPage (bool modal = false, bool animate = true);
 
@@ -17,7 +17,7 @@ namespace FreshMvvm.Maui
         /// </summary>
         /// <returns>The BagePageModel, allows you to PopToRoot, Pass Data</returns>
         /// <param name="newSelected">The pagemodel of the root you want to change</param>
-        Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel;
+        Task<IFreshPageModel> SwitchSelectedRootPageModel<T>() where T : class, IFreshPageModel;
 
         void NotifyChildrenPageWasPopped();
     }

--- a/src/FreshMvvm.Maui/IFreshPageModel.cs
+++ b/src/FreshMvvm.Maui/IFreshPageModel.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using System.Collections.ObjectModel;
+
+namespace FreshMvvm.Maui;
+
+public interface IFreshPageModel : INotifyPropertyChanged
+{
+    /// <summary>
+    /// This event is raise when a page is Popped, this might not be raise everytime a page is Popped. 
+    /// Note* this might be raised multiple times. 
+    /// </summary>
+    event EventHandler PageWasPopped;
+    /// <summary>
+    /// This property is used by the FreshBaseContentPage and allows you to set the toolbar items on the page.
+    /// </summary>
+    ObservableCollection<ToolbarItem> ToolbarItems { get; set; }
+    /// <summary>
+    /// The previous page model, that's automatically filled, on push
+    /// </summary>
+    IFreshPageModel PreviousPageModel { get; set; }
+    /// <summary>
+    /// A reference to the current page, that's automatically filled, on push
+    /// </summary>
+    Page CurrentPage { get; set; }
+    void SetCurrentPage(Page page);
+    /// <summary>
+    /// Core methods are basic built in methods for the App including Pushing, Pop and Alert
+    /// </summary>
+    IPageModelCoreMethods CoreMethods { get; set; }
+    /// <summary>
+    /// This method is called when a page is Pop'd, it also allows for data to be returned.
+    /// </summary>
+    /// <param name="returnedData">This data that's returned from </param>
+    void ReverseInit(object returnedData);
+    /// <summary>
+    /// This method is called when the PageModel is loaded, the initData is the data that's sent from pagemodel before
+    /// </summary>
+    /// <param name="initData">Data that's sent to this PageModel from the pusher</param>
+    void Init(object initData);
+    /// <summary>
+    /// Is true when this model is the first of a new navigation stack
+    /// </summary>
+    public bool IsModalFirstChild { get; set; }
+    /// <summary>
+    /// Used when a page is shown modal and wants a new Navigation Stack
+    /// </summary>
+    public IFreshNavigationService PreviousNavigationService { get; }
+    /// <summary>
+    /// Used when a page is shown modal and wants a new Navigation Stack
+    /// </summary>
+    public IFreshNavigationService CurrentNavigationService { get; }
+    
+    public void SetPreviousNavigationService(IFreshNavigationService freshNavigationService);
+    /// <summary>
+    /// To be used only when creating your own navigation container
+    /// </summary>
+    public void SetCurrentNavigationService(IFreshNavigationService freshNavigationService);
+    /// <summary>
+    /// This means the current PageModel is shown modally and can be pop'd modally
+    /// </summary>
+    bool IsModalAndHasPreviousNavigationStack();
+    public void RaisePageWasPopped();
+}

--- a/src/FreshMvvm.Maui/IPageModelCoreMethods.cs
+++ b/src/FreshMvvm.Maui/IPageModelCoreMethods.cs
@@ -12,17 +12,17 @@ namespace FreshMvvm.Maui
 
         Task<bool> DisplayAlert (string title, string message, string accept, string cancel);
 
-        Task PushPageModel<T> (object data, bool modal = false, bool animate = true) where T : FreshBasePageModel;
+        Task PushPageModel<T> (object data, bool modal = false, bool animate = true) where T : class, IFreshPageModel;
 
-        Task PushPageModel<T, TPage> (object data, bool modal = false, bool animate = true) where T : FreshBasePageModel where TPage : Page;
+        Task PushPageModel<T, TPage> (object data, bool modal = false, bool animate = true) where T : class, IFreshPageModel where TPage : Page;
 
         Task PopPageModel (bool modal = false, bool animate = true);
 
         Task PopPageModel (object data, bool modal = false, bool animate = true);
 
-        Task PushPageModel<T> (bool animate = true) where T : FreshBasePageModel;
+        Task PushPageModel<T> (bool animate = true) where T : class, IFreshPageModel;
 
-        Task PushPageModel<T, TPage> (bool animate = true) where T : FreshBasePageModel where TPage : Page;
+        Task PushPageModel<T, TPage> (bool animate = true) where T : class, IFreshPageModel where TPage : Page;
 
         Task PushPageModel (Type pageModelType, bool animate = true);
 
@@ -38,7 +38,7 @@ namespace FreshMvvm.Maui
         /// </summary>
         /// <param name="removeAll">Will remove all, otherwise it will just remove first on from the top of the stack</param>
         /// <typeparam name="TPageModel">The 1st type parameter.</typeparam>
-        void RemoveFromNavigation<TPageModel> (bool removeAll = false) where TPageModel : FreshBasePageModel;
+        void RemoveFromNavigation<TPageModel> (bool removeAll = false) where TPageModel : class, IFreshPageModel;
 
         /// <summary>
         /// Removes specific page/pagemodel from navigation
@@ -51,15 +51,15 @@ namespace FreshMvvm.Maui
         /// This method pushes a new PageModel modally with a new NavigationContainer
         /// </summary>
         /// <returns>Returns the name of the new service</returns>
-        Task<FreshNavigationContainer> PushPageModelWithNewNavigation<T> (object data, bool animate = true) where T : FreshBasePageModel;
+        Task<FreshNavigationContainer> PushPageModelWithNewNavigation<T> (object data, bool animate = true) where T : class, IFreshPageModel;
 
-        Task PushNewNavigationServiceModal (IFreshNavigationService newNavigationService, FreshBasePageModel[] basePageModels, bool animate = true);
+        Task PushNewNavigationServiceModal (IFreshNavigationService newNavigationService, IFreshPageModel[] basePageModels, bool animate = true);
 
-        Task PushNewNavigationServiceModal (FreshTabbedNavigationContainer tabbedNavigationContainer, FreshBasePageModel basePageModel = null, bool animate = true);
+        Task PushNewNavigationServiceModal (FreshTabbedNavigationContainer tabbedNavigationContainer, IFreshPageModel basePageModel = null, bool animate = true);
 
-        Task PushNewNavigationServiceModal (FreshMasterDetailNavigationContainer masterDetailContainer, FreshBasePageModel basePageModel = null, bool animate = true);
+        Task PushNewNavigationServiceModal (FreshMasterDetailNavigationContainer masterDetailContainer, IFreshPageModel basePageModel = null, bool animate = true);
 
-        Task PushNewNavigationServiceModal (IFreshNavigationService newNavigationService, FreshBasePageModel basePageModels, bool animate = true);
+        Task PushNewNavigationServiceModal (IFreshNavigationService newNavigationService, IFreshPageModel basePageModels, bool animate = true);
 
         Task PopModalNavigationService(bool animate = true);
 
@@ -70,28 +70,28 @@ namespace FreshMvvm.Maui
         /// </summary>
         /// <returns>The BagePageModel, allows you to PopToRoot, Pass Data</returns>
         /// <param name="newSelected">The pagemodel of the root you want to change</param>
-        Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel;
+        Task<IFreshPageModel> SwitchSelectedRootPageModel<T>() where T : class, IFreshPageModel;
 
         /// <summary>
         /// This method is used when you want to switch the selected page, 
         /// </summary>
         /// <returns>The BagePageModel, allows you to PopToRoot, Pass Data</returns>
         /// <param name="newSelectedTab">The pagemodel of the root you want to change</param>
-        Task<FreshBasePageModel> SwitchSelectedTab<T>() where T : FreshBasePageModel;
+        Task<IFreshPageModel> SwitchSelectedTab<T>() where T : class, IFreshPageModel;
 
         /// <summary>
         /// This method is used when you want to switch the selected page, 
         /// </summary>
         /// <returns>The BagePageModel, allows you to PopToRoot, Pass Data</returns>
         /// <param name="newSelectedMaster">The pagemodel of the root you want to change</param>
-        Task<FreshBasePageModel> SwitchSelectedMaster<T>()where T : FreshBasePageModel;
+        Task<IFreshPageModel> SwitchSelectedMaster<T>()where T : class, IFreshPageModel;
 
         Task PopToRoot(bool animate);
 
 		void BatchBegin();
 
 		void BatchCommit();
-        Task PushPageModel<T>(Action<T> setPageModel, bool modal = false, bool animate = true) where T : FreshBasePageModel;
+        Task PushPageModel<T>(Action<T> setPageModel, bool modal = false, bool animate = true) where T : class, IFreshPageModel;
     }
 }
 

--- a/src/FreshMvvm.Maui/NavigationContainers/FreshMasterDetailNavigationContainer.cs
+++ b/src/FreshMvvm.Maui/NavigationContainers/FreshMasterDetailNavigationContainer.cs
@@ -22,10 +22,10 @@ namespace FreshMvvm.Maui
             CreateMenuPage (menuTitle, menuIcon);
         }
 
-        public virtual void AddPage<T> (string title, object data = null) where T : FreshBasePageModel
+        public virtual void AddPage<T> (string title, object data = null) where T : class, IFreshPageModel
         {
             var page = FreshPageModelResolver.ResolvePageModel<T> (data);
-            page.GetModel ().CurrentNavigationService = this;
+            page.GetPageModel ().SetCurrentNavigationService(this);
             _pagesInner.Add(page);
             var navigationContainer = CreateContainerPage (page);
             _pages.Add (title, navigationContainer);
@@ -37,7 +37,7 @@ namespace FreshMvvm.Maui
         {
             var pageModelType = Type.GetType(modelName);
             var page = FreshPageModelResolver.ResolvePageModel(pageModelType, null);
-            page.GetModel().CurrentNavigationService = this;
+            page.GetPageModel().SetCurrentNavigationService(this);
             _pagesInner.Add(page);
             var navigationContainer = CreateContainerPage(page);
             _pages.Add(title, navigationContainer);
@@ -87,7 +87,7 @@ namespace FreshMvvm.Maui
             Flyout = navPage;
         }
 
-        public Task PushPage (Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
+        public Task PushPage (Page page, IFreshPageModel model, bool modal = false, bool animate = true)
         {
             if (modal)
                 return Navigation.PushModalAsync (CreateContainerPageSafe(page));
@@ -126,13 +126,13 @@ namespace FreshMvvm.Maui
                 ((IFreshNavigationService)Detail).NotifyChildrenPageWasPopped();
         }
 
-        public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel
+        public Task<IFreshPageModel> SwitchSelectedRootPageModel<T>() where T : class, IFreshPageModel
         {
-            var tabIndex = _pagesInner.FindIndex(o => o.GetModel().GetType().FullName == typeof(T).FullName);
+            var tabIndex = _pagesInner.FindIndex(o => o.GetPageModel().GetType().FullName == typeof(T).FullName);
 
             _listView.SelectedItem = _pageNames[tabIndex];
 
-            return Task.FromResult((Detail as NavigationPage).CurrentPage.GetModel());
+            return Task.FromResult((Detail as NavigationPage).CurrentPage.GetPageModel());
         }
     }
 }

--- a/src/FreshMvvm.Maui/NavigationContainers/FreshNavigationContainer.cs
+++ b/src/FreshMvvm.Maui/NavigationContainers/FreshNavigationContainer.cs
@@ -8,11 +8,11 @@ namespace FreshMvvm.Maui
     {
         public FreshNavigationContainer (Page page) : base(page)
         {
-            var pageModel = page.GetModel ();
+            var pageModel = page.GetPageModel ();
             if (pageModel == null)
-                throw new InvalidCastException("BindingContext was not a FreshBasePageModel on this Page");
+                throw new InvalidCastException("BindingContext was not a IFreshPageModel on this Page");
 
-            pageModel.CurrentNavigationService = this;
+            pageModel.SetCurrentNavigationService (this);
         }
 
         internal Page CreateContainerPageSafe (Page page)
@@ -28,7 +28,7 @@ namespace FreshMvvm.Maui
             return new NavigationPage (page);
         }
 
-		public virtual Task PushPage (Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
+		public virtual Task PushPage (Page page, IFreshPageModel model, bool modal = false, bool animate = true)
         {
             if (modal)
                 return Navigation.PushModalAsync (CreateContainerPageSafe (page), animate);
@@ -52,7 +52,7 @@ namespace FreshMvvm.Maui
             this.NotifyAllChildrenPopped();
         }
 
-        public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel
+        public Task<IFreshPageModel> SwitchSelectedRootPageModel<T>() where T : class, IFreshPageModel
         {
             throw new Exception("This navigation container has no selected roots, just a single root");
         }

--- a/src/FreshMvvm.Maui/NavigationContainers/FreshTabbedFONavigationContainer.cs
+++ b/src/FreshMvvm.Maui/NavigationContainers/FreshTabbedFONavigationContainer.cs
@@ -22,10 +22,10 @@ namespace FreshMvvm.Maui
             _innerTabbedPage.Title = titleOfFirstTab;
         }
 
-        public virtual Page AddTab<T> (string title, string icon, object data = null) where T : FreshBasePageModel
+        public virtual Page AddTab<T> (string title, string icon, object data = null) where T : class, IFreshPageModel
         {
             var page = FreshPageModelResolver.ResolvePageModel<T> (data);
-            page.GetModel ().CurrentNavigationService = this;
+            page.GetPageModel ().SetCurrentNavigationService (this);
             _tabs.Add (page);
             var container = CreateContainerPageSafe (page);
             container.Title = title;
@@ -48,7 +48,7 @@ namespace FreshMvvm.Maui
             return page;
         }
 
-        public System.Threading.Tasks.Task PushPage (Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
+        public System.Threading.Tasks.Task PushPage (Page page, IFreshPageModel model, bool modal = false, bool animate = true)
         {
             if (modal)
                 return this.Navigation.PushModalAsync (CreateContainerPageSafe (page));
@@ -78,15 +78,15 @@ namespace FreshMvvm.Maui
             }
         }
 
-        public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel
+        public Task<IFreshPageModel> SwitchSelectedRootPageModel<T>() where T : class, IFreshPageModel
         {
             if (this.CurrentPage == _innerTabbedPage)
             {
-                var page = _tabs.FindIndex(o => o.GetModel().GetType().FullName == typeof(T).FullName);
+                var page = _tabs.FindIndex(o => o.GetPageModel().GetType().FullName == typeof(T).FullName);
                 if (page > -1)
                 {
                     _innerTabbedPage.CurrentPage = this._innerTabbedPage.Children[page];
-                    return Task.FromResult(_innerTabbedPage.CurrentPage.GetModel());
+                    return Task.FromResult(_innerTabbedPage.CurrentPage.GetPageModel());
                 }
             }
             else

--- a/src/FreshMvvm.Maui/NavigationContainers/FreshTabbedNavigationContainer.cs
+++ b/src/FreshMvvm.Maui/NavigationContainers/FreshTabbedNavigationContainer.cs
@@ -11,10 +11,10 @@ namespace FreshMvvm.Maui
         List<Page> _tabs = new List<Page>();
         public IEnumerable<Page> TabbedPages { get { return _tabs; } }
 
-        public virtual Page AddTab<T> (string title, string icon, object data = null) where T : FreshBasePageModel
+        public virtual Page AddTab<T> (string title, string icon, object data = null) where T : class, IFreshPageModel
         {
             var page = FreshPageModelResolver.ResolvePageModel<T> (data);
-            page.GetModel ().CurrentNavigationService = this;
+            page.GetPageModel ().SetCurrentNavigationService (this);
             _tabs.Add (page);
             var navigationContainer = CreateContainerPageSafe (page);
             navigationContainer.Title = title;
@@ -37,7 +37,7 @@ namespace FreshMvvm.Maui
             return new NavigationPage (page);
         }
 
-		public System.Threading.Tasks.Task PushPage (Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
+		public System.Threading.Tasks.Task PushPage (Page page, IFreshPageModel model, bool modal = false, bool animate = true)
         {
             if (modal)
                 return this.CurrentPage.Navigation.PushModalAsync (CreateContainerPageSafe (page));
@@ -67,16 +67,16 @@ namespace FreshMvvm.Maui
             }
         }
             
-        public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel
+        public Task<IFreshPageModel> SwitchSelectedRootPageModel<T>() where T : class, IFreshPageModel
         {
-            var page = _tabs.FindIndex(o => o.GetModel().GetType().FullName == typeof(T).FullName);
+            var page = _tabs.FindIndex(o => o.GetPageModel().GetType().FullName == typeof(T).FullName);
 
             if (page > -1)
             {
                 CurrentPage = this.Children[page];
                 var topOfStack = CurrentPage.Navigation.NavigationStack.LastOrDefault();
                 if (topOfStack != null)
-                    return Task.FromResult(topOfStack.GetModel());
+                    return Task.FromResult(topOfStack.GetPageModel());
 
             }
             return null;

--- a/src/FreshMvvm.Maui/PageExtensions.cs
+++ b/src/FreshMvvm.Maui/PageExtensions.cs
@@ -10,19 +10,25 @@ namespace FreshMvvm.Maui
             var pageModel = page.BindingContext as FreshBasePageModel;
             return pageModel;
         }
+        
+        public static IFreshPageModel GetPageModel(this Page page)
+        {
+            var pageModel = page.BindingContext as IFreshPageModel;
+            return pageModel;
+        }
 
         public static void NotifyAllChildrenPopped(this NavigationPage navigationPage)
         {
             foreach (var page in navigationPage.Navigation.ModalStack)
             {
-                var pageModel = page.GetModel();
+                var pageModel = page.GetPageModel();
                 if (pageModel != null)
                     pageModel.RaisePageWasPopped();
             }
 
             foreach (var page in navigationPage.Navigation.NavigationStack)
             {
-                var pageModel = page.GetModel();
+                var pageModel = page.GetPageModel();
                 if (pageModel != null)
                     pageModel.RaisePageWasPopped();
             }

--- a/src/FreshMvvm.Tests/Fixtures/MultipleNavigationProviderTests.cs
+++ b/src/FreshMvvm.Tests/Fixtures/MultipleNavigationProviderTests.cs
@@ -44,8 +44,8 @@ namespace FreshMvvm.Tests
             var masterDetailNavigation = new FreshMasterDetailNavigationContainer();
             masterDetailNavigation.AddPage<MockContentPageModel> ("Page1");
             masterDetailNavigation.AddPage<MockContentPageModel> ("Page2");
-            var pageModel1 = masterDetailNavigation.Pages["Page1"].GetPageFromNav().GetModel();
-            var pageModel2 = masterDetailNavigation.Pages ["Page2"].GetPageFromNav().GetModel();
+            var pageModel1 = masterDetailNavigation.Pages["Page1"].GetPageFromNav().GetPageModel();
+            var pageModel2 = masterDetailNavigation.Pages ["Page2"].GetPageFromNav().GetPageModel();
             pageModel1.CurrentNavigationService.Should().Be(masterDetailNavigation);
             pageModel2.CurrentNavigationService.Should().Be(masterDetailNavigation);
 
@@ -53,8 +53,8 @@ namespace FreshMvvm.Tests
             var tabbedNavigation = new FreshTabbedNavigationContainer();
             tabbedNavigation.AddTab<MockContentPageModel> ("Page1", null);
             tabbedNavigation.AddTab<MockContentPageModel> ("Page2", null);
-            var tabbedPageModel1 = tabbedNavigation.TabbedPages.First().GetModel();
-            var tabbedPageModel2 = tabbedNavigation.TabbedPages.Skip(1).Take(1).First().GetModel();
+            var tabbedPageModel1 = tabbedNavigation.TabbedPages.First().GetPageModel();
+            var tabbedPageModel2 = tabbedNavigation.TabbedPages.Skip(1).Take(1).First().GetPageModel();
             tabbedPageModel1.CurrentNavigationService.Should().Be(tabbedNavigation);
             tabbedPageModel2.CurrentNavigationService.Should().Be(tabbedNavigation);
 
@@ -64,10 +64,10 @@ namespace FreshMvvm.Tests
             var nav = new FreshNavigationContainer(page);
             pageModel.CurrentNavigationService.Should ().Be (nav);
 
-            //standard navigation should throw exception when binding context isn't a FreshBasePageModel
+            //standard navigation should throw exception when binding context isn't a IFreshPageModel
             var pageEx = new Page();
             Action standardNavExeption = () => new FreshNavigationContainer(pageEx);
-            standardNavExeption.Should().Throw<InvalidCastException> ().WithMessage ("BindingContext was not a FreshBasePageModel on this Page");
+            standardNavExeption.Should().Throw<InvalidCastException> ().WithMessage ("BindingContext was not a IFreshPageModel on this Page");
         }
 
         /// <summary>

--- a/src/FreshMvvm.Tests/Mocks/MockPageModelCoreMethods.cs
+++ b/src/FreshMvvm.Tests/Mocks/MockPageModelCoreMethods.cs
@@ -22,7 +22,7 @@ namespace FreshMvvm.Tests.Mocks
 			throw new NotImplementedException();
 		}
 
-	    public Task PushPageModel<T>(Action<T> setPageModel, bool modal = false, bool animate = true) where T : FreshBasePageModel
+	    public Task PushPageModel<T>(Action<T> setPageModel, bool modal = false, bool animate = true) where T : class, IFreshPageModel
 	    {
 	        throw new NotImplementedException();
 	    }
@@ -42,22 +42,22 @@ namespace FreshMvvm.Tests.Mocks
 			throw new NotImplementedException();
 		}
 
-        public Task PushPageModel<T, TPage>(object data, bool modal = false) where T : FreshBasePageModel where TPage : Page
+        public Task PushPageModel<T, TPage>(object data, bool modal = false) where T : class, IFreshPageModel where TPage : Page
         {
             throw new NotImplementedException();
         }
 
-        public Task PushPageModel<T, TPage>() where T : FreshBasePageModel where TPage : Page
+        public Task PushPageModel<T, TPage>() where T : IFreshPageModel where TPage : Page
         {
             throw new NotImplementedException();
         }
 
-        public Task PushNewNavigationServiceModal(FreshTabbedNavigationContainer tabbedNavigationContainer, FreshBasePageModel basePageModel = null)
+        public Task PushNewNavigationServiceModal(FreshTabbedNavigationContainer tabbedNavigationContainer, IFreshPageModel basePageModel = null)
         {
             throw new NotImplementedException();
         }
 
-        public Task PushNewNavigationServiceModal(FreshMasterDetailNavigationContainer masterDetailContainer, FreshBasePageModel basePageModel = null)
+        public Task PushNewNavigationServiceModal(FreshMasterDetailNavigationContainer masterDetailContainer, IFreshPageModel basePageModel = null)
         {
             throw new NotImplementedException();
         }
@@ -87,17 +87,17 @@ namespace FreshMvvm.Tests.Mocks
 			throw new NotImplementedException();
 		}
 
-		public Task PushPageModel<T>() where T : FreshBasePageModel
+		public Task PushPageModel<T>() where T : IFreshPageModel
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task PushPageModel<T>(object data, bool modal = false) where T : FreshBasePageModel
+		public Task PushPageModel<T>(object data, bool modal = false) where T : IFreshPageModel
 		{
 			throw new NotImplementedException();
 		}
 
-        public Task PushNewNavigationServiceModal (IFreshNavigationService newNavigationService, FreshBasePageModel[] basePageModels)
+        public Task PushNewNavigationServiceModal (IFreshNavigationService newNavigationService, IFreshPageModel[] basePageModels)
         {
             throw new NotImplementedException ();
         }
@@ -117,18 +117,18 @@ namespace FreshMvvm.Tests.Mocks
             throw new NotImplementedException ();
         }
 
-        public Task PushNewNavigationServiceModal (IFreshNavigationService newNavigationService, FreshBasePageModel basePageModels)
+        public Task PushNewNavigationServiceModal (IFreshNavigationService newNavigationService, IFreshPageModel basePageModels)
         {
             throw new NotImplementedException ();
         }
 
-        public Task PushPageModel<T>(object data, bool modal = false, bool animate = true) where T : FreshBasePageModel
+        public Task PushPageModel<T>(object data, bool modal = false, bool animate = true) where T : class, IFreshPageModel
         {
             throw new NotImplementedException();
         }
 
         public Task PushPageModel<T, TPage>(object data, bool modal = false, bool animate = true)
-            where T : FreshBasePageModel
+            where T : class, IFreshPageModel
             where TPage : Page
         {
             throw new NotImplementedException();
@@ -144,13 +144,13 @@ namespace FreshMvvm.Tests.Mocks
             throw new NotImplementedException();
         }
 
-        public Task PushPageModel<T>(bool animate = true) where T : FreshBasePageModel
+        public Task PushPageModel<T>(bool animate = true) where T : class, IFreshPageModel
         {
             throw new NotImplementedException();
         }
 
         public Task PushPageModel<T, TPage>(bool animate = true)
-            where T : FreshBasePageModel
+            where T : class, IFreshPageModel
             where TPage : Page
         {
             throw new NotImplementedException();
@@ -166,32 +166,32 @@ namespace FreshMvvm.Tests.Mocks
             throw new NotImplementedException();
         }
 
-        public void RemoveFromNavigation<TPageModel>(bool removeAll = false) where TPageModel : FreshBasePageModel
+        public void RemoveFromNavigation<TPageModel>(bool removeAll = false) where TPageModel : class, IFreshPageModel
         {
             throw new NotImplementedException();
         }
 
-        public Task<string> PushPageModelWithNewNavigation<T>(object data, bool animate = true) where T : FreshBasePageModel
+        public Task<string> PushPageModelWithNewNavigation<T>(object data, bool animate = true) where T : IFreshPageModel
         {
             throw new NotImplementedException();
         }
 
-        public Task PushNewNavigationServiceModal(IFreshNavigationService newNavigationService, FreshBasePageModel[] basePageModels, bool animate = true)
+        public Task PushNewNavigationServiceModal(IFreshNavigationService newNavigationService, IFreshPageModel[] basePageModels, bool animate = true)
         {
             throw new NotImplementedException();
         }
 
-        public Task PushNewNavigationServiceModal(FreshTabbedNavigationContainer tabbedNavigationContainer, FreshBasePageModel basePageModel = null, bool animate = true)
+        public Task PushNewNavigationServiceModal(FreshTabbedNavigationContainer tabbedNavigationContainer, IFreshPageModel basePageModel = null, bool animate = true)
         {
             throw new NotImplementedException();
         }
 
-        public Task PushNewNavigationServiceModal(FreshMasterDetailNavigationContainer masterDetailContainer, FreshBasePageModel basePageModel = null, bool animate = true)
+        public Task PushNewNavigationServiceModal(FreshMasterDetailNavigationContainer masterDetailContainer, IFreshPageModel basePageModel = null, bool animate = true)
         {
             throw new NotImplementedException();
         }
 
-        public Task PushNewNavigationServiceModal(IFreshNavigationService newNavigationService, FreshBasePageModel basePageModels, bool animate = true)
+        public Task PushNewNavigationServiceModal(IFreshNavigationService newNavigationService, IFreshPageModel basePageModels, bool animate = true)
         {
             throw new NotImplementedException();
         }
@@ -201,17 +201,17 @@ namespace FreshMvvm.Tests.Mocks
             throw new NotImplementedException();
         }
 
-        public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel
+        public Task<IFreshPageModel> SwitchSelectedRootPageModel<T>() where T : class, IFreshPageModel
         {
             throw new NotImplementedException();
         }
 
-        public Task<FreshBasePageModel> SwitchSelectedTab<T>() where T : FreshBasePageModel
+        public Task<IFreshPageModel> SwitchSelectedTab<T>() where T : class, IFreshPageModel
         {
             throw new NotImplementedException();
         }
 
-        public Task<FreshBasePageModel> SwitchSelectedMaster<T>() where T : FreshBasePageModel
+        public Task<IFreshPageModel> SwitchSelectedMaster<T>() where T : class, IFreshPageModel
         {
             throw new NotImplementedException();
         }

--- a/src/FreshMvvm.sln
+++ b/src/FreshMvvm.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreshMvvm.Tests", "FreshMvv
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreshMvvm.Maui", "FreshMvvm.Maui\FreshMvvm.Maui.csproj", "{5F23F631-C204-4F75-98B7-772EF7F8EE46}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreshMvvm.Maui.Observable", "FreshMvvm.Maui.Observable\FreshMvvm.Maui.Observable.csproj", "{754B023B-3F63-4F17-9193-EBC73552A3EE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,6 +32,10 @@ Global
 		{5F23F631-C204-4F75-98B7-772EF7F8EE46}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5F23F631-C204-4F75-98B7-772EF7F8EE46}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5F23F631-C204-4F75-98B7-772EF7F8EE46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{754B023B-3F63-4F17-9193-EBC73552A3EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{754B023B-3F63-4F17-9193-EBC73552A3EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{754B023B-3F63-4F17-9193-EBC73552A3EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{754B023B-3F63-4F17-9193-EBC73552A3EE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/FreshMvvmApp/FreshMvvmApp.csproj
+++ b/src/FreshMvvmApp/FreshMvvmApp.csproj
@@ -46,10 +46,12 @@
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	  <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="All" />
+	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\FreshMvvm.Maui\FreshMvvm.Maui.csproj" />
+	  <ProjectReference Include="..\FreshMvvm.Maui.Observable\FreshMvvm.Maui.Observable.csproj" />
 	</ItemGroup>
 	
 </Project>

--- a/src/FreshMvvmApp/Navigation/CustomImplementedNav.cs
+++ b/src/FreshMvvmApp/Navigation/CustomImplementedNav.cs
@@ -62,7 +62,7 @@ namespace FreshMvvmApp
 			Flyout = new NavigationPage(_menuPage) { Title = "Menu" };
 		}
 
-        public virtual async Task PushPage (Page page, FreshBasePageModel model, bool modal = false, bool animated = true)
+        public virtual async Task PushPage (Page page, IFreshPageModel model, bool modal = false, bool animated = true)
 		{
 			if (modal)
                 await Navigation.PushModalAsync (new NavigationPage(page), animated);
@@ -94,16 +94,16 @@ namespace FreshMvvmApp
             }
         }
 
-        public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T> () where T : FreshBasePageModel
+        public Task<IFreshPageModel> SwitchSelectedRootPageModel<T> () where T : class, IFreshPageModel
         {
-            if (_contactsPage.GetModel ().GetType ().FullName == typeof (T).FullName) {
+            if (_contactsPage.GetPageModel ().GetType ().FullName == typeof (T).FullName) {
                 _tabbedNavigationPage.CurrentPage = _contactsPage;
-                return Task.FromResult(_contactsPage.GetModel ());
+                return Task.FromResult(_contactsPage.GetPageModel());
             }
 
-            if (_quotesPage.GetModel ().GetType ().FullName == typeof (T).FullName) {
+            if (_quotesPage.GetPageModel ().GetType ().FullName == typeof (T).FullName) {
                 _tabbedNavigationPage.CurrentPage = _quotesPage;
-                return Task.FromResult(_quotesPage.GetModel ());
+                return Task.FromResult(_quotesPage.GetPageModel ());
             }
 
             throw new Exception ("Cannot do this");

--- a/src/FreshMvvmApp/PageModels/ContactPageModel.cs
+++ b/src/FreshMvvmApp/PageModels/ContactPageModel.cs
@@ -1,12 +1,13 @@
-﻿using Microsoft.Maui.Controls;
-using PropertyChanged;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using FreshMvvm.Maui;
 using System;
+using FreshMvvm.Maui.Observable;
+using System.Threading.Tasks;
 
 namespace FreshMvvmApp
 {
-    [PropertyChanged.AddINotifyPropertyChangedInterface]
-    public class ContactPageModel : FreshBasePageModel
+    public partial class ContactPageModel : FreshBaseObservablePageModel
     {
         IDatabaseService _dataService;
 
@@ -22,7 +23,8 @@ namespace FreshMvvmApp
             //handle the property changed, nice
         }
 
-        public Contact Contact { get; set; }
+        [ObservableProperty]
+        Contact _contact;
 
         public override void Init (object initData)
         {
@@ -33,60 +35,44 @@ namespace FreshMvvmApp
             }
         }
 
-        public Command SaveCommand {
-            get { 
-                return new Command (() => {
-                    _dataService.UpdateContact (Contact);
-                    CoreMethods.PopPageModel (Contact);
-                }
-                );
-            }
+        [RelayCommand]
+        private void Save()
+        {
+            _dataService.UpdateContact(Contact);
+            CoreMethods.PopPageModel(Contact);
         }
 
-        public Command TestModal {
-            get {
-                return new Command (async () => {
-                    await CoreMethods.PushPageModel<ModalPageModel> (null, true);
-                });
-            }
+        [RelayCommand]
+        private Task TestModal()
+        {
+            return CoreMethods.PushPageModel<ModalPageModel>(null, true);
         }
 
-        public Command TestModalNavigationBasic {
-            get {
-                return new Command (async () => {
-
-                    var page = FreshPageModelResolver.ResolvePageModel<MainMenuPageModel> ();
-                    var basicNavContainer = new FreshNavigationContainer (page);
-                    await CoreMethods.PushNewNavigationServiceModal(basicNavContainer, new FreshBasePageModel[] { page.GetModel() }); 
-                });
-            }
+        [RelayCommand]
+        private Task TestModalNavigationBasic()
+        {
+            var page = FreshPageModelResolver.ResolvePageModel<MainMenuPageModel>();
+            var basicNavContainer = new FreshNavigationContainer(page);
+            return CoreMethods.PushNewNavigationServiceModal(basicNavContainer, new FreshBasePageModel[] { page.GetModel() });
         }
 
-
-        public Command TestModalNavigationTabbed {
-            get {
-                return new Command (async () => {
-
-                    var tabbedNavigation = new FreshTabbedNavigationContainer ();
-                    tabbedNavigation.AddTab<ContactListPageModel> ("Contacts", "contacts", null);
-                    tabbedNavigation.AddTab<QuoteListPageModel> ("Quotes", "document", null);
-                    await CoreMethods.PushNewNavigationServiceModal(tabbedNavigation);
-                });
-            }
+        [RelayCommand]
+        private Task TestModalNavigationTabbed()
+        {
+            var tabbedNavigation = new FreshTabbedNavigationContainer();
+            tabbedNavigation.AddTab<ContactListPageModel>("Contacts", "contacts", null);
+            tabbedNavigation.AddTab<QuoteListPageModel>("Quotes", "document", null);
+            return CoreMethods.PushNewNavigationServiceModal(tabbedNavigation);
         }
 
-        public Command TestModalNavigationMasterDetail {
-            get {
-                return new Command (async () => {
-
-                    var masterDetailNav = new FreshMasterDetailNavigationContainer ();
-                    masterDetailNav.Init ("Menu", "menu");
-                    masterDetailNav.AddPage<ContactListPageModel> ("Contacts", null);
-                    masterDetailNav.AddPage<QuoteListPageModel> ("Quotes", null);
-                    await CoreMethods.PushNewNavigationServiceModal(masterDetailNav); 
-
-                });
-            }
+        [RelayCommand]
+        private Task TestModalNavigationMasterDetail()
+        {
+            var masterDetailNav = new FreshMasterDetailNavigationContainer();
+            masterDetailNav.Init("Menu", "menu");
+            masterDetailNav.AddPage<ContactListPageModel>("Contacts", null);
+            masterDetailNav.AddPage<QuoteListPageModel>("Quotes", null);
+            return CoreMethods.PushNewNavigationServiceModal(masterDetailNav);
         }
     }
 }

--- a/src/FreshMvvmApp/Pages/ContactPage.xaml
+++ b/src/FreshMvvmApp/Pages/ContactPage.xaml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <local:BasePage xmlns="http://schemas.microsoft.com/dotnet/2021/maui" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="FreshMvvmApp.ContactPage"
-		xmlns:local="clr-namespace:FreshMvvmApp;assembly=FreshMvvmApp" >
+		xmlns:local="clr-namespace:FreshMvvmApp;assembly=FreshMvvmApp"
+		x:DataType="local:ContactPageModel" >
 	<local:BasePage.Content>
 		<StackLayout Padding="15">
 			<Label Text="Contact Name" ></Label>
@@ -9,10 +10,10 @@
 			<Entry Text="{Binding Contact.Phone}"></Entry>
 			<Button Text="Save" Command="{Binding SaveCommand}"></Button>
 			<BoxView HeightRequest="30"></BoxView>
-			<Button Text="Test Modal" Command="{Binding TestModal}"></Button>
-			<Button Text="Test Modal with Navigation (Basic)" Command="{Binding TestModalNavigationBasic}"></Button>
-			<Button Text="Test Modal with Navigation (Tabbed)" Command="{Binding TestModalNavigationTabbed}"></Button>
-			<Button Text="Test Modal with Navigation (MasterDetail)" Command="{Binding TestModalNavigationMasterDetail}"></Button>
+			<Button Text="Test Modal" Command="{Binding TestModalCommand}"></Button>
+			<Button Text="Test Modal with Navigation (Basic)" Command="{Binding TestModalNavigationBasicCommand}"></Button>
+			<Button Text="Test Modal with Navigation (Tabbed)" Command="{Binding TestModalNavigationTabbedCommand}"></Button>
+			<Button Text="Test Modal with Navigation (MasterDetail)" Command="{Binding TestModalNavigationMasterDetailCommand}"></Button>
 		</StackLayout>
 	</local:BasePage.Content>
 </local:BasePage>


### PR DESCRIPTION
Introduced IFreshPageModel, FreshMvvm.Maui.Observable, and refactor.

Intention is to create a separate package called something like "FreshMvvm.Maui.Observable" if you want to use FreshMvvm.Maui with the CommunityToolkit.Mvvm.

This means the original FreshMvvm.Maui library will not have a dependency on CommunityToolkit.Mvvm if developers don't use it.

This approach, however,  adds extra complexity that might not give enough value, especially if many developers end up using CommunityToolkit.Mvvm. 