### PR TITLE
CommunityToolkit.Mvvm support simpler option

### DIFF
--- a/src/FreshMvvm.Maui/FreshBasePageModel.cs
+++ b/src/FreshMvvm.Maui/FreshBasePageModel.cs
@@ -1,19 +1,14 @@
 ﻿using System;
-using System.ComponentModel;
-using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using System.Runtime.CompilerServices;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace FreshMvvm.Maui
 {
-    public abstract class FreshBasePageModel : INotifyPropertyChanged
+    public abstract class FreshBasePageModel : ObservableObject
     {
         NavigationPage _navigationPage;
-
-        public event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>
         /// This event is raise when a page is Popped, this might not be raise everytime a page is Popped. 
@@ -57,12 +52,10 @@ namespace FreshMvvm.Maui
         {
         }
 
+        [Obsolete("Use OnPropertyChanged instead")]
         protected void RaisePropertyChanged([CallerMemberName] string propertyName = null)
         {
-            var handler = PropertyChanged;
-            if (handler != null) {
-                handler(this, new PropertyChangedEventArgs(propertyName));
-            }
+            OnPropertyChanged(propertyName);
         }
 
         internal void WireEvents(Page page)

--- a/src/FreshMvvm.Maui/FreshMvvm.Maui.csproj
+++ b/src/FreshMvvm.Maui/FreshMvvm.Maui.csproj
@@ -34,6 +34,7 @@
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	  <PackageReference Include="System.Reactive" Version="5.0.0" />
+	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 	</ItemGroup>
 
 </Project>

--- a/src/FreshMvvmApp/FreshMvvmApp.csproj
+++ b/src/FreshMvvmApp/FreshMvvmApp.csproj
@@ -46,6 +46,7 @@
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	  <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="All" />
+	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/FreshMvvmApp/PageModels/ContactPageModel.cs
+++ b/src/FreshMvvmApp/PageModels/ContactPageModel.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.Maui.Controls;
-using PropertyChanged;
-using FreshMvvm.Maui;
+﻿using FreshMvvm.Maui;
 using System;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Threading.Tasks;
 
 namespace FreshMvvmApp
 {
-    [PropertyChanged.AddINotifyPropertyChangedInterface]
-    public class ContactPageModel : FreshBasePageModel
+    public partial class ContactPageModel : FreshBasePageModel
     {
         IDatabaseService _dataService;
 
@@ -22,7 +22,8 @@ namespace FreshMvvmApp
             //handle the property changed, nice
         }
 
-        public Contact Contact { get; set; }
+        [ObservableProperty]
+        Contact _contact;
 
         public override void Init (object initData)
         {
@@ -33,60 +34,44 @@ namespace FreshMvvmApp
             }
         }
 
-        public Command SaveCommand {
-            get { 
-                return new Command (() => {
-                    _dataService.UpdateContact (Contact);
-                    CoreMethods.PopPageModel (Contact);
-                }
-                );
-            }
+        [RelayCommand]
+        private void Save()
+        {
+            _dataService.UpdateContact(Contact);
+            CoreMethods.PopPageModel(Contact);
         }
 
-        public Command TestModal {
-            get {
-                return new Command (async () => {
-                    await CoreMethods.PushPageModel<ModalPageModel> (null, true);
-                });
-            }
+        [RelayCommand]
+        private Task TestModal()
+        {
+            return CoreMethods.PushPageModel<ModalPageModel>(null, true);
         }
 
-        public Command TestModalNavigationBasic {
-            get {
-                return new Command (async () => {
-
-                    var page = FreshPageModelResolver.ResolvePageModel<MainMenuPageModel> ();
-                    var basicNavContainer = new FreshNavigationContainer (page);
-                    await CoreMethods.PushNewNavigationServiceModal(basicNavContainer, new FreshBasePageModel[] { page.GetModel() }); 
-                });
-            }
+        [RelayCommand]
+        private Task TestModalNavigationBasic()
+        {
+            var page = FreshPageModelResolver.ResolvePageModel<MainMenuPageModel>();
+            var basicNavContainer = new FreshNavigationContainer(page);
+            return CoreMethods.PushNewNavigationServiceModal(basicNavContainer, new FreshBasePageModel[] { page.GetModel() });
         }
 
-
-        public Command TestModalNavigationTabbed {
-            get {
-                return new Command (async () => {
-
-                    var tabbedNavigation = new FreshTabbedNavigationContainer ();
-                    tabbedNavigation.AddTab<ContactListPageModel> ("Contacts", "contacts", null);
-                    tabbedNavigation.AddTab<QuoteListPageModel> ("Quotes", "document", null);
-                    await CoreMethods.PushNewNavigationServiceModal(tabbedNavigation);
-                });
-            }
+        [RelayCommand]
+        private Task TestModalNavigationTabbed()
+        {
+            var tabbedNavigation = new FreshTabbedNavigationContainer();
+            tabbedNavigation.AddTab<ContactListPageModel>("Contacts", "contacts", null);
+            tabbedNavigation.AddTab<QuoteListPageModel>("Quotes", "document", null);
+            return CoreMethods.PushNewNavigationServiceModal(tabbedNavigation);
         }
 
-        public Command TestModalNavigationMasterDetail {
-            get {
-                return new Command (async () => {
-
-                    var masterDetailNav = new FreshMasterDetailNavigationContainer ();
-                    masterDetailNav.Init ("Menu", "menu");
-                    masterDetailNav.AddPage<ContactListPageModel> ("Contacts", null);
-                    masterDetailNav.AddPage<QuoteListPageModel> ("Quotes", null);
-                    await CoreMethods.PushNewNavigationServiceModal(masterDetailNav); 
-
-                });
-            }
+        [RelayCommand]
+        private Task TestModalNavigationMasterDetail()
+        {
+            var masterDetailNav = new FreshMasterDetailNavigationContainer();
+            masterDetailNav.Init("Menu", "menu");
+            masterDetailNav.AddPage<ContactListPageModel>("Contacts", null);
+            masterDetailNav.AddPage<QuoteListPageModel>("Quotes", null);
+            return CoreMethods.PushNewNavigationServiceModal(masterDetailNav);
         }
     }
 }

--- a/src/FreshMvvmApp/Pages/ContactPage.xaml
+++ b/src/FreshMvvmApp/Pages/ContactPage.xaml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <local:BasePage xmlns="http://schemas.microsoft.com/dotnet/2021/maui" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="FreshMvvmApp.ContactPage"
-		xmlns:local="clr-namespace:FreshMvvmApp;assembly=FreshMvvmApp" >
+		xmlns:local="clr-namespace:FreshMvvmApp;assembly=FreshMvvmApp"
+		x:DataType="local:ContactPageModel" >
 	<local:BasePage.Content>
 		<StackLayout Padding="15">
 			<Label Text="Contact Name" ></Label>
@@ -9,10 +10,10 @@
 			<Entry Text="{Binding Contact.Phone}"></Entry>
 			<Button Text="Save" Command="{Binding SaveCommand}"></Button>
 			<BoxView HeightRequest="30"></BoxView>
-			<Button Text="Test Modal" Command="{Binding TestModal}"></Button>
-			<Button Text="Test Modal with Navigation (Basic)" Command="{Binding TestModalNavigationBasic}"></Button>
-			<Button Text="Test Modal with Navigation (Tabbed)" Command="{Binding TestModalNavigationTabbed}"></Button>
-			<Button Text="Test Modal with Navigation (MasterDetail)" Command="{Binding TestModalNavigationMasterDetail}"></Button>
+			<Button Text="Test Modal" Command="{Binding TestModalCommand}"></Button>
+			<Button Text="Test Modal with Navigation (Basic)" Command="{Binding TestModalNavigationBasicCommand}"></Button>
+			<Button Text="Test Modal with Navigation (Tabbed)" Command="{Binding TestModalNavigationTabbedCommand}"></Button>
+			<Button Text="Test Modal with Navigation (MasterDetail)" Command="{Binding TestModalNavigationMasterDetailCommand}"></Button>
 		</StackLayout>
 	</local:BasePage.Content>
 </local:BasePage>


### PR DESCRIPTION
Refactor FreshBasePageModel to inherit from ObservableObject.

This is the simpler option to support CommunityToolkit.Mvvm to allow PageModels to make use of the CommunityToolkit.Mvvm, however it introduces a dependency on the package into FreshMvvm.Maui. This is probably ok as its likely this will be a very popular choice with the community.